### PR TITLE
[Architecture]: Fix GitHub Project Status Automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,168 @@
+name: GitHub Project Automation
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no changes made)'
+        required: false
+        default: 'false'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-to-project:
+    name: Add to Project with Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        continue-on-error: true
+
+      - name: Set token
+        id: set-token
+        run: |
+          if [ -n "${{ steps.generate-token.outputs.token }}" ]; then
+            echo "token=${{ steps.generate-token.outputs.token }}" >> $GITHUB_OUTPUT
+            echo "Using GitHub App token"
+          elif [ -n "${{ secrets.PROJECT_PAT }}" ]; then
+            echo "token=${{ secrets.PROJECT_PAT }}" >> $GITHUB_OUTPUT
+            echo "Using PROJECT_PAT"
+          else
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "Warning: Using GITHUB_TOKEN - may have limited permissions"
+          fi
+
+      - name: Add Issue to Project
+        if: github.event_name == 'issues'
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/CodingButter/projects/9
+          github-token: ${{ steps.set-token.outputs.token }}
+        id: add-issue
+
+      - name: Add PR to Project
+        if: github.event_name == 'pull_request'
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/CodingButter/projects/9
+          github-token: ${{ steps.set-token.outputs.token }}
+        id: add-pr
+
+      - name: Get Project Data
+        id: project-data
+        env:
+          GH_TOKEN: ${{ steps.set-token.outputs.token }}
+        run: |
+          # Get the item ID from previous step
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            ITEM_ID="${{ steps.add-issue.outputs.itemId }}"
+          else
+            ITEM_ID="${{ steps.add-pr.outputs.itemId }}"
+          fi
+          
+          echo "item_id=$ITEM_ID" >> $GITHUB_OUTPUT
+          
+          # Get project field IDs
+          PROJECT_DATA=$(gh api graphql -f query='
+            {
+              user(login: "CodingButter") {
+                projectV2(number: 9) {
+                  id
+                  fields(first: 20) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }')
+          
+          # Extract field and option IDs
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id')
+          STATUS_FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.fields.nodes[] | select(.name == "Status") | .id')
+          BACKLOG_OPTION_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Backlog") | .id')
+          
+          echo "project_id=$PROJECT_ID" >> $GITHUB_OUTPUT
+          echo "status_field_id=$STATUS_FIELD_ID" >> $GITHUB_OUTPUT
+          echo "backlog_option_id=$BACKLOG_OPTION_ID" >> $GITHUB_OUTPUT
+          
+          # Debug output
+          echo "Project ID: $PROJECT_ID"
+          echo "Status Field ID: $STATUS_FIELD_ID"
+          echo "Backlog Option ID: $BACKLOG_OPTION_ID"
+          echo "Item ID: $ITEM_ID"
+
+      - name: Set Status to Backlog
+        if: steps.project-data.outputs.item_id != ''
+        env:
+          GH_TOKEN: ${{ steps.set-token.outputs.token }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "DRY RUN: Would set status to Backlog for item ${{ steps.project-data.outputs.item_id }}"
+            exit 0
+          fi
+          
+          # Set the status to Backlog
+          RESPONSE=$(gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(
+                input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }
+              ) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' \
+            -F projectId="${{ steps.project-data.outputs.project_id }}" \
+            -F itemId="${{ steps.project-data.outputs.item_id }}" \
+            -F fieldId="${{ steps.project-data.outputs.status_field_id }}" \
+            -F optionId="${{ steps.project-data.outputs.backlog_option_id }}")
+          
+          echo "Status update response: $RESPONSE"
+          
+          # Check if the update was successful
+          if echo "$RESPONSE" | jq -e '.data.updateProjectV2ItemFieldValue.projectV2Item.id' > /dev/null; then
+            echo "✅ Successfully set status to Backlog"
+          else
+            echo "❌ Failed to set status to Backlog"
+            echo "$RESPONSE"
+            exit 1
+          fi
+
+      - name: Report Status
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "✅ Automation completed successfully"
+            if [ "${{ github.event_name }}" = "issues" ]; then
+              echo "Issue #${{ github.event.issue.number }} added to project with Backlog status"
+            else
+              echo "PR #${{ github.event.pull_request.number }} added to project with Backlog status"
+            fi
+          else
+            echo "⚠️ Automation encountered issues - manual intervention may be required"
+            echo "Check the logs above for details"
+          fi

--- a/.github/workflows/status-enforcement.yml
+++ b/.github/workflows/status-enforcement.yml
@@ -1,0 +1,260 @@
+name: Project Status Enforcement
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no changes made)'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Enable verbose logging'
+        required: false
+        default: 'true'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  enforce-status:
+    name: Enforce Project Status
+    runs-on: ubuntu-latest
+    outputs:
+      fixed_count: ${{ steps.enforce.outputs.fixed_count }}
+      issues_fixed: ${{ steps.enforce.outputs.issues_fixed }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        continue-on-error: true
+
+      - name: Set token
+        id: set-token
+        run: |
+          if [ -n "${{ steps.generate-token.outputs.token }}" ]; then
+            echo "token=${{ steps.generate-token.outputs.token }}" >> $GITHUB_OUTPUT
+            echo "Using GitHub App token"
+          elif [ -n "${{ secrets.PROJECT_PAT }}" ]; then
+            echo "token=${{ secrets.PROJECT_PAT }}" >> $GITHUB_OUTPUT
+            echo "Using PROJECT_PAT"
+          else
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+            echo "Warning: Using GITHUB_TOKEN - may have limited permissions"
+          fi
+
+      - name: Check and Fix Missing Status
+        id: enforce
+        env:
+          GH_TOKEN: ${{ steps.set-token.outputs.token }}
+        run: |
+          echo "🔍 Checking for items without status..."
+          
+          # Get all project items and their status
+          PROJECT_DATA=$(gh api graphql -f query='
+            {
+              user(login: "CodingButter") {
+                projectV2(number: 9) {
+                  id
+                  fields(first: 20) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue {
+                          number
+                          title
+                        }
+                        ... on PullRequest {
+                          number
+                          title
+                        }
+                      }
+                      fieldValues(first: 10) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field {
+                              ... on ProjectV2SingleSelectField {
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }')
+          
+          # Extract necessary IDs
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.id')
+          STATUS_FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.fields.nodes[] | select(.name == "Status") | .id')
+          BACKLOG_OPTION_ID=$(echo "$PROJECT_DATA" | jq -r '.data.user.projectV2.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "Backlog") | .id')
+          
+          # Find items without status
+          ITEMS_WITHOUT_STATUS=$(echo "$PROJECT_DATA" | jq -r '
+            .data.user.projectV2.items.nodes[] |
+            select(
+              (.fieldValues.nodes | map(select(.field.name == "Status")) | length) == 0
+            ) |
+            {
+              id: .id,
+              number: .content.number,
+              title: .content.title
+            }
+          ')
+          
+          FIXED_COUNT=0
+          ISSUES_FIXED=""
+          
+          if [ -z "$ITEMS_WITHOUT_STATUS" ]; then
+            echo "✅ All items have a status assigned!"
+          else
+            echo "⚠️ Found items without status:"
+            echo "$ITEMS_WITHOUT_STATUS" | jq -r '. | "  - #\(.number): \(.title)"'
+            
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo ""
+              echo "🏃 DRY RUN MODE - No changes will be made"
+              COUNT=$(echo "$ITEMS_WITHOUT_STATUS" | jq -s 'length')
+              echo "Would fix $COUNT items"
+            else
+              echo ""
+              echo "🔧 Fixing items by setting status to Backlog..."
+              
+              # Process each item
+              echo "$ITEMS_WITHOUT_STATUS" | jq -c '.' | while read -r item; do
+                ITEM_ID=$(echo "$item" | jq -r '.id')
+                ITEM_NUMBER=$(echo "$item" | jq -r '.number')
+                ITEM_TITLE=$(echo "$item" | jq -r '.title')
+                
+                if [ "${{ inputs.verbose }}" = "true" ]; then
+                  echo "  Updating item #$ITEM_NUMBER..."
+                fi
+                
+                # Update the status
+                UPDATE_RESPONSE=$(gh api graphql -f query='
+                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                    updateProjectV2ItemFieldValue(
+                      input: {
+                        projectId: $projectId
+                        itemId: $itemId
+                        fieldId: $fieldId
+                        value: { singleSelectOptionId: $optionId }
+                      }
+                    ) {
+                      projectV2Item {
+                        id
+                      }
+                    }
+                  }' \
+                  -F projectId="$PROJECT_ID" \
+                  -F itemId="$ITEM_ID" \
+                  -F fieldId="$STATUS_FIELD_ID" \
+                  -F optionId="$BACKLOG_OPTION_ID" 2>&1)
+                
+                if echo "$UPDATE_RESPONSE" | jq -e '.data.updateProjectV2ItemFieldValue.projectV2Item.id' > /dev/null 2>&1; then
+                  echo "  ✅ Fixed #$ITEM_NUMBER: $ITEM_TITLE"
+                  FIXED_COUNT=$((FIXED_COUNT + 1))
+                  if [ -z "$ISSUES_FIXED" ]; then
+                    ISSUES_FIXED="#$ITEM_NUMBER"
+                  else
+                    ISSUES_FIXED="$ISSUES_FIXED, #$ITEM_NUMBER"
+                  fi
+                else
+                  echo "  ❌ Failed to fix #$ITEM_NUMBER: $ITEM_TITLE"
+                  if [ "${{ inputs.verbose }}" = "true" ]; then
+                    echo "     Error: $UPDATE_RESPONSE"
+                  fi
+                fi
+              done
+            fi
+          fi
+          
+          echo "fixed_count=$FIXED_COUNT" >> $GITHUB_OUTPUT
+          echo "issues_fixed=$ISSUES_FIXED" >> $GITHUB_OUTPUT
+          
+          # Summary
+          echo ""
+          echo "📊 Summary:"
+          echo "  - Items checked: $(echo "$PROJECT_DATA" | jq '.data.user.projectV2.items.nodes | length')"
+          echo "  - Items without status: $(echo "$ITEMS_WITHOUT_STATUS" | jq -s 'length')"
+          echo "  - Items fixed: $FIXED_COUNT"
+          if [ -n "$ISSUES_FIXED" ]; then
+            echo "  - Issues fixed: $ISSUES_FIXED"
+          fi
+
+      - name: Create Issue Report
+        if: steps.enforce.outputs.fixed_count != '0' && inputs.dry_run != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.set-token.outputs.token }}
+          script: |
+            const fixedCount = '${{ steps.enforce.outputs.fixed_count }}';
+            const issuesFixed = '${{ steps.enforce.outputs.issues_fixed }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            
+            const body = `## 🔧 Project Status Enforcement Report
+            
+            The automated status enforcement workflow has detected and fixed items without status.
+            
+            ### Summary
+            - **Items Fixed**: ${fixedCount}
+            - **Issue Numbers**: ${issuesFixed}
+            - **Default Status Applied**: Backlog
+            
+            ### Action Required
+            Please review the items that were automatically assigned to Backlog and update their status if needed:
+            - ${issuesFixed.split(', ').map(num => `[${num}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/issues/${num.replace('#', '')})`).join('\n- ')}
+            
+            ### Why Did This Happen?
+            Items can end up without status due to:
+            - Manual project board manipulation
+            - API errors during issue/PR creation
+            - GitHub Actions workflow failures
+            - Direct GraphQL API usage without status assignment
+            
+            ### Workflow Run
+            [View the enforcement run](${runUrl})
+            
+            ---
+            *This is an automated report from the status enforcement workflow.*`;
+            
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Automation] Fixed ${fixedCount} items without project status`,
+              body: body,
+              labels: ['automation', 'project-management']
+            });
+
+      - name: Report Results
+        if: always()
+        run: |
+          echo "🎯 Status Enforcement Complete"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "This was a DRY RUN - no changes were made"
+          elif [ "${{ steps.enforce.outputs.fixed_count }}" = "0" ]; then
+            echo "No items needed fixing - all items have proper status!"
+          else
+            echo "Fixed ${{ steps.enforce.outputs.fixed_count }} items"
+          fi


### PR DESCRIPTION
## Problem
Issues were being created without status in the GitHub project, violating our architectural requirements.

### Issues Fixed
- #65: Missing status → Set to Backlog
- #64: Missing status → Set to Backlog  
- #62: Missing status → Set to Backlog

## Solution Implemented

### 1. Immediate Fix
- Used GraphQL API to set all issues without status to 'Backlog'
- Verified all 27 issues now have proper status

### 2. Preventive Automation
Created two GitHub Actions workflows:

#### project-automation.yml
- Triggers on issue/PR creation
- Automatically adds to project #9
- Sets default status to 'Backlog'
- Uses PROJECT_PAT for permissions
- Includes fallback to GitHub App token

#### status-enforcement.yml  
- Runs hourly via cron schedule
- Scans for any items without status
- Automatically fixes them to 'Backlog'
- Creates issue report when fixes are applied
- Includes dry-run mode for testing

## Architecture Decision
This enforces our requirement that NO issue should ever be in 'No Status' state. The dual-layer approach ensures:
1. New items get status immediately (project-automation)
2. Any that slip through are caught within an hour (status-enforcement)

## Testing
- Manually fixed existing issues via GraphQL
- Workflows will be tested once merged to development
- Can be manually triggered with dry-run mode

## Success Metrics
- Zero issues in 'No Status' state
- All new issues automatically get 'Backlog' status
- Hourly enforcement catches any edge cases
- Automated reports track any interventions

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>